### PR TITLE
Add Update the return-status of a single return action to ReturnResource

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    monta_api (0.1.3)
+    monta_api (0.1.4)
       activesupport (~> 7.0)
       faraday (~> 2.5)
       zeitwerk (~> 2.6)

--- a/lib/monta_api/resources/return_resource.rb
+++ b/lib/monta_api/resources/return_resource.rb
@@ -45,8 +45,15 @@ module MontaAPI
     #
     # Response:
     #   "Successfully changed the statuses of multiple ReturnLines"
-    def follow_up(return_id:, attributes:)
+    def follow_up_multiple_lines(return_id:, attributes:)
       put_request("return/#{return_id}/update_return_status/multiple_lines", body: attributes).body
+    end
+
+    # @client.return.follow_up(return_id: "123456", status: "Refunded")
+    # Response:
+    #   "Successfully changed status of return '123456' from 'none' to 'Refunded'."
+    def follow_up(return_id:, status:)
+      put_request("return/#{return_id}/update_return_status/#{status}", body: {}).body
     end
   end
 end

--- a/lib/monta_api/version.rb
+++ b/lib/monta_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MontaAPI
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
- Update the exising follow_up action to follow_up_multiple_lines
- Add follow_up action to update the return-status of a single return